### PR TITLE
[Chore]: Update release version to 0.2.0-alpha.5

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "Pibrary"
 copyright = "2023, Prakash Chaudhary"
 author = "Prakash Chaudhary"
-release = "0.2.0-alpha.1"
+release = "0.2.0-alpha.5"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pibrary"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "A package of reusable code for ML projects."
 authors = ["Prakash Chaudhary <connectwithprakash@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
This fixes the release issue during deployment.

<!-- readthedocs-preview pibrary start -->
----
📚 Documentation preview 📚: https://pibrary--28.org.readthedocs.build/en/28/

<!-- readthedocs-preview pibrary end -->